### PR TITLE
Remove usage of functions removed from sphinx

### DIFF
--- a/ext/descriptions_string.py
+++ b/ext/descriptions_string.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from docutils import nodes, core
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 from mdp import __short_description__ as short_description
 from mdp import __doc__ as long_description

--- a/ext/download_links.py
+++ b/ext/download_links.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from docutils import nodes
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 from mdp import __version__
 

--- a/ext/version_string.py
+++ b/ext/version_string.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from docutils import nodes
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 from mdp import __version__, __authors__, __homepage__, __contact__
 


### PR DESCRIPTION
make_admonition was removed in sphinx 1.4.2, and the whole
compat module a bit later.

Necessary to make this build on F26+.